### PR TITLE
Fixed Taste of Heaven and Intergalactic High Song Effects not looping on desktop

### DIFF
--- a/Helicopter.Core/Helicopter/Game1.cs
+++ b/Helicopter.Core/Helicopter/Game1.cs
@@ -1009,7 +1009,19 @@ namespace Helicopter.Core
 			this.eventTimes[22] = 161327f;
 			this.eventTimes[23] = 165362f;
 			this.eventTimes[24] = 207988f;
-			this.eventTimes[25] = 210000f;
+
+			if (IsDesktop && IsOpenGL)
+			{
+                // On desktop & openGL, elapsedMilliseconds is calculated as the song player's milliseconds - 1000
+                // The Taste of Heaven song is 210790ms long, meaning the song player never goes above 209790 while the event was 210000.
+				// This means that this event was never triggered and the choreography never got reset.
+                this.eventTimes[25] = 208750f;
+			} 
+			else
+			{
+				// Original Timing
+				this.eventTimes[25] = 210000f;
+			}
 		}
 
 		private void LoadEventInfoIntergalacticalHigh()

--- a/Helicopter.Core/Helicopter/Game1.cs
+++ b/Helicopter.Core/Helicopter/Game1.cs
@@ -1044,8 +1044,19 @@ namespace Helicopter.Core
 			this.eventTimes[15] = 198234f;
 			this.eventTimes[16] = 220383f;
 			this.eventTimes[17] = 231247f;
-			this.eventTimes[18] = 232553f;
-		}
+            if (IsDesktop && IsOpenGL)
+            {
+                // On desktop & openGL, elapsedMilliseconds is calculated as the song player's milliseconds - 1000
+                // The Intergalatical High song is 233082ms long, meaning the song player never goes above 232082 while the event was 232553.
+                // This means that this event was never triggered and the choreography never got reset.
+                this.eventTimes[18] = 231750f;
+            }
+            else
+            {
+                // Original Timing
+                this.eventTimes[18] = 232553f;
+            }
+        }
 
 		private void LoadEventInfoMyRainbow()
 		{


### PR DESCRIPTION
Fixed an issue on desktop and openGL where the Taste of Heaven Song's last event (the one that causes the effects to loop) timestamp happens 1 second after song ends, causing effects to not loop properly.